### PR TITLE
Fix white screen in Pokemon Emerald

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -243,7 +243,7 @@ static const ini_t gbaover[256] = {
 			{"Pokemon - Edicion Rojo Fuego (Spain)",				"BPRS",	131072,	1,	0,	0,	0},
 			{"Pokemon - Edicion Verde Hoja (Spain)",				"BPGS",	131072,	1,	0,	0,	0},
 			{"Pokemon - Eidicion Zafiro (Spain)",					"AXPS",	131072,	0,	1,	0,	0},
-			{"Pokemon - Emerald Version (USA, Europe)",				"BPEE",	0,	0,	1,	0,	0},
+			{"Pokemon - Emerald Version (USA, Europe)",				"BPEE",	131072,	0,	1,	0,	0},
 			{"Pokemon - Feuerrote Edition (Germany)",				"BPRD",	131072,	0,	0,	0,	0},
 			{"Pokemon - Fire Red Version (USA, Europe)",				"BPRE",	131072,	0,	0,	0,	0},
 			{"Pokemon - Leaf Green Version (USA, Europe)",				"BPGE",	131072,	0,	0,	0,	0},


### PR DESCRIPTION
Updated the internal vba-over entry for romid "BPEE" to use a flashSize of 128K over the default 64K.
