### PR TITLE
Fix TILED_RENDERING with MSVC

### DIFF
--- a/src/gba.cpp
+++ b/src/gba.cpp
@@ -6006,12 +6006,12 @@ union u8h
    struct
 #ifdef LSB_FIRST
    {
-      /* 0*/	unsigned lo:4;
-      /* 4*/	unsigned hi:4;
+      /* 0*/	unsigned char lo:4;
+      /* 4*/	unsigned char hi:4;
 #else
    {
-      /* 4*/	unsigned hi:4;
-      /* 0*/	unsigned lo:4;
+      /* 4*/	unsigned char hi:4;
+      /* 0*/	unsigned char lo:4;
 #endif
    }
    __pragma(pack(pop));


### PR DESCRIPTION
Should fix TILED_RENDERING with MSVC compiles.
__pragma( pack(push, 1)); only changes the alignment to 1 byte, MSVC will still take the type specifier to determine the minimum size of the struct.
