### PR TITLE
Fix ~33MB leaked RAM on core unload.

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -356,7 +356,10 @@ static void gba_init(void)
    free(state_buf);
 }
 
-void retro_deinit(void) {}
+void retro_deinit(void)
+{
+	CPUCleanUp();
+}
 
 void retro_reset(void)
 {

--- a/src/gba.cpp
+++ b/src/gba.cpp
@@ -8251,7 +8251,7 @@ static bool CPUIsELF(const char *file)
 }
 #endif
 
-static void CPUCleanUp (void)
+void CPUCleanUp (void)
 {
 	if(rom != NULL) {
 		free(rom);

--- a/src/gba.h
+++ b/src/gba.h
@@ -111,6 +111,7 @@ extern int CPULoadRom(const char *);
 extern void doMirroring(bool);
 extern void CPUUpdateRegister(uint32_t, uint16_t);
 extern void CPUInit(const char *,bool);
+extern void CPUCleanUp (void);
 extern void CPUReset (void);
 extern void CPULoop(void);
 extern void CPUCheckDMA(int,int);


### PR DESCRIPTION
retro_deinit isn't supposed to be blank if the core allocates anything. Let's make it not blank. (The leak may be present in non-Next VBA too; I'll take a look right now.)
