### PR TITLE
the always_inline attribute must be prepended with inline as of GCC 4.7

### DIFF
--- a/src/port.h
+++ b/src/port.h
@@ -92,7 +92,7 @@
  #if defined(_MSC_VER)
   #define FORCE_INLINE __forceinline
  #elif defined(__GNUC__)
-  #define FORCE_INLINE __attribute__((always_inline))
+  #define FORCE_INLINE inline __attribute__((always_inline))
  #else
   #define FORCE_INLINE INLINE
  #endif


### PR DESCRIPTION
This fixes the build error I was having on linux x86_64
