### PR TITLE
Adding X and Y Buttons as extra keys for L and R

### DIFF
--- a/libretro/libretro.cpp
+++ b/libretro/libretro.cpp
@@ -423,7 +423,9 @@ static const unsigned binds[] = {
 	RETRO_DEVICE_ID_JOYPAD_UP,
 	RETRO_DEVICE_ID_JOYPAD_DOWN,
 	RETRO_DEVICE_ID_JOYPAD_R,
-	RETRO_DEVICE_ID_JOYPAD_L
+	RETRO_DEVICE_ID_JOYPAD_L,
+	RETRO_DEVICE_ID_JOYPAD_X,
+	RETRO_DEVICE_ID_JOYPAD_Y
 };
 
 static const unsigned binds2[] = {
@@ -436,7 +438,9 @@ static const unsigned binds2[] = {
 	RETRO_DEVICE_ID_JOYPAD_UP,
 	RETRO_DEVICE_ID_JOYPAD_DOWN,
 	RETRO_DEVICE_ID_JOYPAD_R,
-	RETRO_DEVICE_ID_JOYPAD_L
+	RETRO_DEVICE_ID_JOYPAD_L,
+	RETRO_DEVICE_ID_JOYPAD_X,
+	RETRO_DEVICE_ID_JOYPAD_Y
 };
 
 static unsigned has_frame;
@@ -569,6 +573,8 @@ bool retro_load_game(const struct retro_game_info *game)
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R,     "R" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Select" },
       { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "L" },
+      { 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "R" },
 
       { 0 },
    };


### PR DESCRIPTION
Adding X and Y Buttons as extra keys for L and R which is very handy for certain games specially fighting and fast paced action alike street fighter alpha 3 and sonic battle