### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - ubuntu-toolchain-r-test
 env:
   global:
-    - CORE=snes9x2010
+    - CORE=vba_next
     - COMPILER_NAME=gcc CXX=g++-7 CC=gcc-7
   matrix:
     - PLATFORM=linux_x64


### PR DESCRIPTION
Travis has been building wrong core all this time. This PR fixes it by replacing it with the correct core target "vba_next".