### PR TITLE
Improve support for Run Ahead feature

### DIFF
--- a/src/sound.cpp
+++ b/src/sound.cpp
@@ -2112,8 +2112,9 @@ static variable_desc gba_state [] =
 
 	// Emulator
 	LOAD( int, soundEnableFlag ),
+	LOAD( int, soundTicks ),
 
-	SKIP( int [15], room_for_expansion ),
+	SKIP( int [14], room_for_expansion ),
 
 	{ NULL, 0 }
 };


### PR DESCRIPTION
Solves sound problems when using Run Ahead is enabled. This should not broke any existing save states since a reserved variable was already allocated in save struct.