### PR TITLE
GBA BIOS: ArcTan/ArcTan2 fixes for HLE bios

### DIFF
--- a/src/gba.cpp
+++ b/src/gba.cpp
@@ -1361,9 +1361,13 @@ static inline int16_t fast_cos(uint8_t val)
 	return fast_sin(val + 0x40);
 }
 
+// 2020-08-12 negativeExponent
+// ArcTan/ArcTan2 fixes based from mgba hle bios
+
 static void BIOS_ArcTan (void)
 {
-	s32 a =  -(((s32)(bus.reg[0].I*bus.reg[0].I)) >> 14);
+	s32 i = bus.reg[0].I;
+	s32 a =  -((i * i) >> 14);
 	s32 b = ((0xA9 * a) >> 14) + 0x390;
 	b = ((b * a) >> 14) + 0x91C;
 	b = ((b * a) >> 14) + 0xFB6;
@@ -1371,8 +1375,9 @@ static void BIOS_ArcTan (void)
 	b = ((b * a) >> 14) + 0x2081;
 	b = ((b * a) >> 14) + 0x3651;
 	b = ((b * a) >> 14) + 0xA2F9;
-	a = ((s32)bus.reg[0].I * b) >> 16;
-	bus.reg[0].I = a;
+	bus.reg[0].I = (i * b) >> 16;
+    bus.reg[1].I = a;
+    bus.reg[3].I = b;
 }
 
 static void BIOS_Div (void)
@@ -1423,6 +1428,7 @@ static void BIOS_ArcTan2 (void)
 		}
 	}
 	bus.reg[0].I = res;
+	bus.reg[3].I = 0x170;
 }
 
 static void BIOS_BitUnPack (void)


### PR DESCRIPTION
* Fix ArcTan and ArcTan2 based on mgba's hle bios fixes
- mgba-emu/mgba@14dc014#diff-8f06a143a9fd912c83209f935d3aca25
- mgba-emu/mgba@b154457#diff-8f06a143a9fd912c83209f935d3aca25